### PR TITLE
fix: Enable plugin usage in ESM projects by replacing require.resolve with hybrid resolver

### DIFF
--- a/test/dual-module-support.test.ts
+++ b/test/dual-module-support.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest"
+import { createRequire } from "node:module"
+
+describe("Dual Module Support", () => {
+  it("can be imported as ESM", async () => {
+    const plugin = await import("../dist/index.mjs")
+    expect(plugin.default).toBeDefined()
+    expect(typeof plugin.default).toBe("function")
+    const instance = plugin.default()
+    expect(instance.name).toBe("pino")
+    expect(instance.setup).toBeDefined()
+  })
+
+  it("can be required as CommonJS", () => {
+    const require = createRequire(import.meta.url)
+    const plugin = require("../dist/index.js")
+    expect(plugin).toBeDefined()
+    expect(typeof plugin).toBe("function")
+    const instance = plugin()
+    expect(instance.name).toBe("pino")
+    expect(instance.setup).toBeDefined()
+  })
+
+  it("both module types return equivalent plugins", async () => {
+    const esmPlugin = await import("../dist/index.mjs")
+    const require = createRequire(import.meta.url)
+    const cjsPlugin = require("../dist/index.js")
+    
+    const esmInstance = esmPlugin.default()
+    const cjsInstance = cjsPlugin()
+    
+    expect(esmInstance.name).toBe(cjsInstance.name)
+    expect(typeof esmInstance.setup).toBe(typeof cjsInstance.setup)
+  })
+
+  it("hybridResolve works in both contexts", async () => {
+    // This tests that our hybridResolve function works
+    // The plugin internally uses hybridResolve to find pino and thread-stream
+    const plugin = await import("../dist/index.mjs")
+    const instance = plugin.default({ transports: ["pino-pretty"] })
+    
+    // If hybridResolve works, the plugin will initialize without errors
+    expect(instance).toBeDefined()
+    expect(instance.name).toBe("pino")
+  })
+})


### PR DESCRIPTION
## Problem

The plugin currently fails when used in ESM projects because `require.resolve()` is not available in ESM contexts, causing runtime errors like:

```
ReferenceError: require is not defined
```

This prevents users from using the plugin in modern ESM-based build setups.

## Solution

Replace `require.resolve()` calls with a hybrid resolver that works in both CommonJS and ESM environments:

- In CJS contexts: Use native `require.resolve()`  
- In ESM contexts: Use `createRequire(import.meta.url).resolve()`

## Changes

- Add hybrid module resolution using Node.js `createRequire` API
- Replace 3 `require.resolve()` calls with the hybrid resolver
- Remove broken ESM fallback code that was causing syntax errors
- Add comprehensive tests for dual module compatibility

## Testing

- ✅ All existing tests pass (no breaking changes)
- ✅ New tests verify plugin works in both CJS and ESM contexts
- ✅ Plugin can be imported via both `require()` and `import`
- ✅ Bundling works correctly in both module systems

## Backward Compatibility

Fully backward compatible - no changes to the plugin's API or behavior in CommonJS environments.